### PR TITLE
Add routed marketing pages and integrate tube light navigation

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { GraduationCap, Handshake, Home, Lightbulb } from "lucide-react";
+
+import MarketingPage from "@/components/marketing-page";
+
+export default function AboutPage() {
+  return (
+    <MarketingPage
+      eyebrow="Who We Are"
+      title="Binghamton innovators building big-brand experiences for small business"
+      description="SaltedPixel was founded by Binghamton University School of Management students who believe local companies deserve the same polish and automation as national brands."
+      primaryCta={{ label: "Meet the team", href: "/contact" }}
+      secondaryCta={{ label: "Back to home", href: "/", icon: <Home className="h-5 w-5" /> }}
+      highlights={[
+        {
+          icon: <GraduationCap className="h-6 w-6" />,
+          title: "Business-first thinking",
+          description: "We pair marketing strategy with modern development so every project drives revenue, not just clicks."
+        },
+        {
+          icon: <Lightbulb className="h-6 w-6" />,
+          title: "Always experimenting",
+          description: "From AI workflows to design trends, we test new ideas weekly and bring the best to our clients."
+        },
+        {
+          icon: <Handshake className="h-6 w-6" />,
+          title: "Partners, not vendors",
+          description: "You get transparent communication, proactive recommendations, and a team that sticks around after launch."
+        }
+      ]}
+      footerNote="Grounded in Upstate NY • Growing bold brands everywhere"
+    />
+  );
+}

--- a/app/consultation/page.tsx
+++ b/app/consultation/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { BarChart3, ClipboardCheck, Home, Smile } from "lucide-react";
+
+import MarketingPage from "@/components/marketing-page";
+
+export default function ConsultationPage() {
+  return (
+    <MarketingPage
+      eyebrow="Free Strategy Session"
+      title="Get actionable insights before you ever sign on"
+      description="Our consultation is a collaborative workshop where we audit your digital presence and highlight quick wins. You'll walk away with prioritized recommendations whether or not we work together."
+      primaryCta={{ label: "Reserve your consultation", href: "/get-started" }}
+      secondaryCta={{ label: "Back to home", href: "/", icon: <Home className="h-5 w-5" /> }}
+      highlights={[
+        {
+          icon: <ClipboardCheck className="h-6 w-6" />,
+          title: "360° audit",
+          description: "We review your current site, search visibility, and automations to uncover gaps and opportunities."
+        },
+        {
+          icon: <BarChart3 className="h-6 w-6" />,
+          title: "Roadmap & KPIs",
+          description: "Expect a concise action plan with metrics to track so you know exactly what success looks like."
+        },
+        {
+          icon: <Smile className="h-6 w-6" />,
+          title: "Zero-pressure vibe",
+          description: "Use the insights on your own or partner with us—either way, you'll have clarity on your next move."
+        }
+      ]}
+      footerNote="Consultations are limited each month to ensure every conversation is high-impact."
+    />
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { Clock, Headset, Home, MessageSquare } from "lucide-react";
+
+import MarketingPage from "@/components/marketing-page";
+
+export default function ContactPage() {
+  return (
+    <MarketingPage
+      eyebrow="Let's Talk"
+      title="Tell us about your next big milestone"
+      description="Drop us a note and we’ll follow up within one business day with tailored next steps. Prefer to talk it through? We can hop on a quick call or video chat to get you moving."
+      primaryCta={{ label: "Send us an email", href: "mailto:hello@saltedpixel.com" }}
+      secondaryCta={{ label: "Back to home", href: "/", icon: <Home className="h-5 w-5" /> }}
+      highlights={[
+        {
+          icon: <MessageSquare className="h-6 w-6" />,
+          title: "Share your vision",
+          description: "Tell us about your audience, your goals, and where you need momentum—we'll guide the rest."
+        },
+        {
+          icon: <Headset className="h-6 w-6" />,
+          title: "Live strategy sessions",
+          description: "Hop on a call with our founders to unpack your ideas and sketch an action plan in real time."
+        },
+        {
+          icon: <Clock className="h-6 w-6" />,
+          title: "Quick responses",
+          description: "Expect a thoughtful reply or meeting invite within 24 hours, often much faster."
+        }
+      ]}
+      footerNote="Prefer text? Add (555) 123-4567 to your contacts—SMS automations coming soon."
+    />
+  );
+}

--- a/app/get-started/page.tsx
+++ b/app/get-started/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { CalendarCheck, Compass, Home, Layers } from "lucide-react";
+
+import MarketingPage from "@/components/marketing-page";
+
+export default function GetStartedPage() {
+  return (
+    <MarketingPage
+      eyebrow="Launch With Confidence"
+      title="Let's map out your custom growth system"
+      description="Tell us about your goals, your customers, and the challenges holding your business back. We'll prepare a tailored SaltedPixel roadmap before our first call so you can see the opportunities ahead."
+      primaryCta={{ label: "Schedule a discovery session", href: "/contact" }}
+      secondaryCta={{ label: "Back to home", href: "/", icon: <Home className="h-5 w-5" /> }}
+      highlights={[
+        {
+          icon: <Compass className="h-6 w-6" />,
+          title: "Guided onboarding",
+          description: "A short intake form gathers the essentials so we can jump straight into solutions when we meet."
+        },
+        {
+          icon: <Layers className="h-6 w-6" />,
+          title: "System blueprint",
+          description: "Understand how your website, SEO, and automations will work together in one cohesive plan."
+        },
+        {
+          icon: <CalendarCheck className="h-6 w-6" />,
+          title: "Flexible scheduling",
+          description: "Pick a time that fits your calendar—we offer evening and weekend slots for busy owners."
+        }
+      ]}
+      footerNote="Every engagement begins with a conversation—no obligations, just ideas."
+    />
+  );
+}

--- a/app/growth-system/page.tsx
+++ b/app/growth-system/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { Bot, Globe, Home, LineChart } from "lucide-react";
+
+import MarketingPage from "@/components/marketing-page";
+
+export default function GrowthSystemPage() {
+  return (
+    <MarketingPage
+      eyebrow="The SaltedPixel Method"
+      title="A complete growth system engineered for local business"
+      description="We blend stunning design, local search visibility, and AI automation into one integrated platform. Each layer is built to reinforce the others so that your website becomes the engine powering every lead."
+      primaryCta={{ label: "See our service lineup", href: "/services" }}
+      secondaryCta={{ label: "Back to home", href: "/", icon: <Home className="h-5 w-5" /> }}
+      highlights={[
+        {
+          icon: <Globe className="h-6 w-6" />,
+          title: "Web experiences built to convert",
+          description: "Modern, responsive sites that showcase your brand and make it effortless for visitors to take action."
+        },
+        {
+          icon: <LineChart className="h-6 w-6" />,
+          title: "Local SEO momentum",
+          description: "From citations to content, we amplify your visibility so you appear right when customers search."
+        },
+        {
+          icon: <Bot className="h-6 w-6" />,
+          title: "Automation that delights",
+          description: "AI-powered follow-up keeps conversations moving even when you're focused on running the business."
+        }
+      ]}
+      footerNote="Web • Search • Automation — unified for measurable growth."
+    />
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,11 +4,15 @@ export const metadata = {
 };
 
 import "./../styles/globals.css";
+import { MainNav } from "@/components/main-nav";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className="relative min-h-screen bg-background text-foreground">
+        <MainNav />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { motion, useScroll, useTransform, useInView, useSpring } from "framer-motion";
 import { 
   Globe, 
@@ -259,9 +260,15 @@ function SaltedPixelWebsite() {
 
     {/* Navigation links (moved left) */}
     <div className="hidden md:flex items-center space-x-8">
-      <a href="#services" className="text-gray-300 hover:text-white transition-colors">Services</a>
-      <a href="#about" className="text-gray-300 hover:text-white transition-colors">About</a>
-      <a href="#contact" className="text-gray-300 hover:text-white transition-colors">Contact</a>
+      <Link href="/services" className="text-gray-300 hover:text-white transition-colors">
+        Services
+      </Link>
+      <Link href="/about" className="text-gray-300 hover:text-white transition-colors">
+        About
+      </Link>
+      <Link href="/contact" className="text-gray-300 hover:text-white transition-colors">
+        Contact
+      </Link>
     </div>
   </motion.div>
 
@@ -271,8 +278,14 @@ function SaltedPixelWebsite() {
     animate={{ opacity: 1, x: 0 }}
     transition={{ duration: 0.6, delay: 0.4 }}
   >
-    <Button className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700">
-      Get Started
+    <Button
+      asChild
+      className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+    >
+      <Link href="/get-started" className="flex items-center gap-2">
+        Get Started
+        <ArrowRight className="w-4 h-4" />
+      </Link>
     </Button>
   </motion.div>
 </nav>
@@ -325,19 +338,26 @@ function SaltedPixelWebsite() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 1.0 }}
           >
-            <Button 
-              size="lg" 
+            <Button
+              asChild
+              size="lg"
               className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 px-8 py-4 text-lg"
             >
-              Start Your Growth Journey
-              <ArrowRight className="w-5 h-5 ml-2" />
+              <Link href="/growth-system" className="flex items-center gap-2">
+                Start Your Growth Journey
+                <ArrowRight className="w-5 h-5" />
+              </Link>
             </Button>
-            <Button 
-              variant="outline" 
-              size="lg" 
+            <Button
+              asChild
+              variant="outline"
+              size="lg"
               className="border-white/20 text-white hover:bg-white/10 px-8 py-4 text-lg"
             >
-              View Our Work
+              <Link href="/work" className="flex items-center gap-2">
+                <Star className="w-5 h-5 text-blue-300" />
+                View Our Work
+              </Link>
             </Button>
           </motion.div>
         </motion.div>
@@ -423,12 +443,15 @@ function SaltedPixelWebsite() {
             with ongoing support that keeps you ahead of the competition.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-6">
-            <Button 
-              size="lg" 
+            <Button
+              asChild
+              size="lg"
               className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 px-8 py-4 text-lg"
             >
-              Get Your Free Consultation
-              <ArrowRight className="w-5 h-5 ml-2" />
+              <Link href="/consultation" className="flex items-center gap-2">
+                Get Your Free Consultation
+                <ArrowRight className="w-5 h-5" />
+              </Link>
             </Button>
             <div className="flex items-center text-gray-300">
               <CheckCircle className="w-5 h-5 mr-2 text-green-400" />

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { Bot, Home, Layout, Search } from "lucide-react";
+
+import MarketingPage from "@/components/marketing-page";
+
+export default function ServicesPage() {
+  return (
+    <MarketingPage
+      eyebrow="What We Deliver"
+      title="Services designed to work together from day one"
+      description="Pick individual solutions or let us orchestrate the full SaltedPixel system. Every engagement is strategy-led, transparent, and focused on measurable outcomes."
+      primaryCta={{ label: "Start a project", href: "/get-started" }}
+      secondaryCta={{ label: "Back to home", href: "/", icon: <Home className="h-5 w-5" /> }}
+      highlights={[
+        {
+          icon: <Layout className="h-6 w-6" />,
+          title: "Conversion-focused websites",
+          description: "High-impact visuals, clear storytelling, and UX best practices tuned for local audiences."
+        },
+        {
+          icon: <Search className="h-6 w-6" />,
+          title: "Local SEO acceleration",
+          description: "Technical optimizations, content, and reviews working together to dominate neighborhood searches."
+        },
+        {
+          icon: <Bot className="h-6 w-6" />,
+          title: "AI-powered automations",
+          description: "Smart chat, instant follow-up, and internal workflows that give you hours back every week."
+        }
+      ]}
+      footerNote="Mix and match services—our retainers flex as your growth needs evolve."
+    />
+  );
+}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { Home, MonitorSmartphone, Sparkles, TrendingUp } from "lucide-react";
+
+import MarketingPage from "@/components/marketing-page";
+
+export default function WorkPage() {
+  return (
+    <MarketingPage
+      eyebrow="Proof in the Portfolio"
+      title="Recent SaltedPixel launches and growth wins"
+      description="Explore the websites, automations, and SEO campaigns we've crafted for ambitious small businesses. Each project is tailored to the brand—and built to convert."
+      primaryCta={{ label: "Request a featured case study", href: "/contact" }}
+      secondaryCta={{ label: "Back to home", href: "/", icon: <Home className="h-5 w-5" /> }}
+      highlights={[
+        {
+          icon: <Sparkles className="h-6 w-6" />,
+          title: "Standout storytelling",
+          description: "Clean layouts, bold imagery, and messaging that makes your value unforgettable."
+        },
+        {
+          icon: <MonitorSmartphone className="h-6 w-6" />,
+          title: "Mobile-first builds",
+          description: "Lightning-fast experiences that feel native on phones, tablets, and desktops alike."
+        },
+        {
+          icon: <TrendingUp className="h-6 w-6" />,
+          title: "Measurable growth",
+          description: "Detailed analytics, tracking, and reporting so you always know what's working."
+        }
+      ]}
+      footerNote="We're gathering our favorite transformations—check back soon for full case studies."
+    />
+  );
+}

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { NavBar } from "@/components/ui/tubelight-navbar"
+import { Home, User, Briefcase, Sparkles, MessageSquare } from "lucide-react"
+
+const navItems = [
+  { name: "Home", url: "/", icon: Home },
+  { name: "About", url: "/about", icon: User },
+  { name: "Services", url: "/services", icon: Sparkles },
+  { name: "Work", url: "/work", icon: Briefcase },
+  { name: "Contact", url: "/contact", icon: MessageSquare },
+]
+
+export function MainNav() {
+  return <NavBar items={navItems} />
+}

--- a/components/marketing-page.tsx
+++ b/components/marketing-page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface CtaLink {
+  label: string;
+  href: string;
+  icon?: React.ReactNode;
+  variant?: "default" | "outline";
+}
+
+interface Highlight {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+interface MarketingPageProps {
+  eyebrow: string;
+  title: string;
+  description: string;
+  primaryCta: CtaLink;
+  secondaryCta?: CtaLink;
+  highlights: Highlight[];
+  footerNote?: string;
+}
+
+export function MarketingPage({
+  eyebrow,
+  title,
+  description,
+  primaryCta,
+  secondaryCta,
+  highlights,
+  footerNote,
+}: MarketingPageProps) {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-blue-500/20 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-96 w-96 translate-x-1/3 bg-purple-500/20 blur-3xl" />
+      </div>
+
+      <div className="relative">
+        <div className="container mx-auto px-4 pb-16 pt-24">
+          <div className="max-w-3xl">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-sky-200">
+              {eyebrow}
+            </span>
+            <h1 className="mt-8 text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
+              {title}
+            </h1>
+            <p className="mt-6 text-lg text-slate-200 md:text-xl">
+              {description}
+            </p>
+            <div className="mt-10 flex flex-wrap gap-4">
+              <Button
+                asChild
+                size="lg"
+                className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+              >
+                <Link href={primaryCta.href} className="flex items-center gap-2">
+                  {primaryCta.label}
+                  {primaryCta.icon ?? <ArrowRight className="h-5 w-5" />}
+                </Link>
+              </Button>
+              {secondaryCta ? (
+                <Button
+                  asChild
+                  size="lg"
+                  variant={secondaryCta.variant ?? "outline"}
+                  className="border-white/20 text-white hover:bg-white/10"
+                >
+                  <Link href={secondaryCta.href} className="flex items-center gap-2">
+                    {secondaryCta.icon ?? <ArrowLeft className="h-5 w-5" />}
+                    {secondaryCta.label}
+                  </Link>
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="container mx-auto px-4 pb-24">
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {highlights.map((highlight, index) => (
+              <div
+                key={index}
+                className="group rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-white/20 hover:bg-white/10"
+              >
+                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-300">
+                  {highlight.icon}
+                </div>
+                <h2 className="text-xl font-semibold text-white">{highlight.title}</h2>
+                <p className="mt-3 text-slate-200">{highlight.description}</p>
+              </div>
+            ))}
+          </div>
+
+          {footerNote ? (
+            <p className="mt-16 max-w-3xl text-sm uppercase tracking-[0.3em] text-slate-400">
+              {footerNote}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MarketingPage;

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -3,12 +3,22 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends React.HTMLAttributes<HTMLElement> {
   variant?: "default" | "outline";
   size?: "sm" | "lg";
+  asChild?: boolean;
+  type?: React.ButtonHTMLAttributes<HTMLButtonElement>["type"];
 }
 
-export function Button({ className, variant = "default", size = "sm", ...props }: ButtonProps) {
+export function Button({
+  className,
+  variant = "default",
+  size = "sm",
+  asChild = false,
+  children,
+  type = "button",
+  ...props
+}: ButtonProps) {
   const base =
     "inline-flex items-center justify-center rounded-xl font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none";
 
@@ -22,7 +32,18 @@ export function Button({ className, variant = "default", size = "sm", ...props }
     lg: "px-6 py-3 text-lg"
   };
 
+  const classes = cn(base, variants[variant], sizes[size], className);
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      className: cn(classes, children.props.className),
+      ...props,
+    });
+  }
+
   return (
-    <button className={cn(base, variants[variant], sizes[size], className)} {...props} />
+    <button className={classes} type={type} {...props}>
+      {children}
+    </button>
   );
 }

--- a/components/ui/tubelight-navbar.tsx
+++ b/components/ui/tubelight-navbar.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useState } from "react"
+import { motion } from "framer-motion"
+import Link from "next/link"
+import type { LucideIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface NavItem {
+  name: string
+  url: string
+  icon: LucideIcon
+}
+
+interface NavBarProps {
+  items: NavItem[]
+  className?: string
+}
+
+export function NavBar({ items, className }: NavBarProps) {
+  const [activeTab, setActiveTab] = useState(items[0]?.name ?? "")
+
+  return (
+    <div
+      className={cn(
+        "fixed bottom-0 sm:top-0 left-1/2 -translate-x-1/2 z-50 mb-6 sm:pt-6",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3 bg-background/5 border border-border backdrop-blur-lg py-1 px-1 rounded-full shadow-lg">
+        {items.map((item) => {
+          const Icon = item.icon
+          const isActive = activeTab === item.name
+
+          return (
+            <Link
+              key={item.name}
+              href={item.url}
+              onClick={() => setActiveTab(item.name)}
+              className={cn(
+                "relative cursor-pointer text-sm font-semibold px-6 py-2 rounded-full transition-colors",
+                "text-foreground/80 hover:text-primary",
+                isActive && "bg-muted text-primary",
+              )}
+            >
+              <span className="hidden md:inline">{item.name}</span>
+              <span className="md:hidden">
+                <Icon size={18} strokeWidth={2.5} />
+              </span>
+              {isActive && (
+                <motion.div
+                  layoutId="lamp"
+                  className="absolute inset-0 w-full bg-primary/5 rounded-full -z-10"
+                  initial={false}
+                  transition={{
+                    type: "spring",
+                    stiffness: 300,
+                    damping: 30,
+                  }}
+                >
+                  <div className="absolute -top-2 left-1/2 -translate-x-1/2 w-8 h-1 bg-primary rounded-t-full">
+                    <div className="absolute w-12 h-6 bg-primary/20 rounded-full blur-md -top-2 -left-2" />
+                    <div className="absolute w-8 h-6 bg-primary/20 rounded-full blur-md -top-1" />
+                    <div className="absolute w-4 h-4 bg-primary/20 rounded-full blur-sm top-0 left-2" />
+                  </div>
+                </motion.div>
+              )}
+            </Link>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,9 +17,24 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- convert navigation and hero buttons into linked CTAs that point to dedicated routes
- add a reusable marketing page template and create placeholder pages for services, about, contact, get started, growth system, work, and consultation
- update the shared button component so CTAs can render links while keeping styling consistent
- integrate the animated tube light navigation bar into the root layout with icon links to core marketing pages

## Testing
- npm run lint *(blocked by interactive Next.js setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68d828a855b083268613e2dfe2181329