### PR TITLE
Add global navigation bar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,17 +12,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="bg-slate-950 text-white antialiased">
         <div className="relative min-h-screen overflow-hidden">
           <div className="pointer-events-none absolute inset-0 overflow-hidden">
-            <div className="absolute -top-64 left-1/2 h-[42rem] w-[42rem] -translate-x-1/2 rounded-full bg-sky-400/30 blur-[160px]" />
-            <div className="absolute top-1/3 -left-32 h-[28rem] w-[28rem] rounded-full bg-violet-500/25 blur-[160px]" />
-            <div className="absolute bottom-[-20%] right-[-5%] h-[34rem] w-[34rem] rounded-full bg-purple-500/25 blur-[160px]" />
-            <div className="absolute inset-0 opacity-80 mix-blend-screen [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0.75),transparent_72%)]">
-              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.2),transparent_62%)]" />
-              <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(168,85,247,0.18),transparent_70%)]" />
+            <div className="absolute inset-x-0 top-0 h-[38rem] bg-[linear-gradient(to_bottom,#0a1a3f,#132b63_65%,rgba(19,43,99,0))]" />
+            <div className="absolute -top-64 left-1/2 h-[42rem] w-[42rem] -translate-x-1/2 rounded-full bg-sky-400/20 blur-[160px]" />
+            <div className="absolute top-1/3 -left-32 h-[28rem] w-[28rem] rounded-full bg-violet-500/20 blur-[160px]" />
+            <div className="absolute bottom-[-20%] right-[-5%] h-[34rem] w-[34rem] rounded-full bg-purple-500/20 blur-[160px]" />
+            <div className="absolute inset-0 opacity-70 mix-blend-screen [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0.75),transparent_72%)]">
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),transparent_62%)]" />
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(168,85,247,0.16),transparent_70%)]" />
             </div>
-            <div className="absolute inset-0 opacity-25 [mask-image:linear-gradient(to_bottom,rgba(0,0,0,0)_0%,rgba(0,0,0,1)_18%,rgba(0,0,0,1)_82%,rgba(0,0,0,0)_100%)]">
-              <div className="absolute inset-0 bg-[conic-gradient(from_130deg_at_50%_50%,rgba(148,163,184,0.18),transparent_60%,rgba(148,163,184,0.18))]" />
+            <div className="absolute inset-0 opacity-20 [mask-image:linear-gradient(to_bottom,rgba(0,0,0,0)_0%,rgba(0,0,0,1)_18%,rgba(0,0,0,1)_82%,rgba(0,0,0,0)_100%)]">
+              <div className="absolute inset-0 bg-[conic-gradient(from_130deg_at_50%_50%,rgba(148,163,184,0.16),transparent_60%,rgba(148,163,184,0.16))]" />
             </div>
-            <div className="absolute inset-x-0 top-[22%] h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+            <div className="absolute inset-x-0 top-[22%] h-px bg-gradient-to-r from-transparent via-white/15 to-transparent" />
             <div className="absolute inset-x-0 bottom-[18%] h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
           </div>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,11 +4,15 @@ export const metadata = {
 };
 
 import "./../styles/globals.css";
+import SiteNav from "@/components/site-nav";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <SiteNav />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,9 +9,26 @@ import SiteNav from "@/components/site-nav";
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>
-        <SiteNav />
-        {children}
+      <body className="bg-slate-950 text-white">
+        <div className="relative min-h-screen overflow-hidden">
+          <div className="pointer-events-none absolute inset-0 overflow-hidden">
+            <div className="absolute -top-56 left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-blue-500/25 blur-[140px]" />
+            <div className="absolute bottom-[-20%] right-[-5%] h-[30rem] w-[30rem] rounded-full bg-purple-500/25 blur-[140px]" />
+            <div className="absolute inset-0 opacity-70 mix-blend-screen [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0.75),transparent_70%)]">
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),transparent_60%)]" />
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(168,85,247,0.2),transparent_65%)]" />
+            </div>
+            <div className="absolute inset-0 opacity-20 [mask-image:linear-gradient(to_bottom,rgba(0,0,0,0)_0%,rgba(0,0,0,1)_20%,rgba(0,0,0,1)_80%,rgba(0,0,0,0)_100%)]">
+              <div className="absolute inset-0 bg-[conic-gradient(from_120deg_at_50%_50%,rgba(148,163,184,0.2),transparent_60%,rgba(148,163,184,0.2))]" />
+            </div>
+            <div className="absolute inset-x-0 top-1/2 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+          </div>
+
+          <div className="relative z-10 flex min-h-screen flex-col">
+            <SiteNav />
+            <main className="flex-1">{children}</main>
+          </div>
+        </div>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,19 +9,21 @@ import SiteNav from "@/components/site-nav";
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-slate-950 text-white">
+      <body className="bg-slate-950 text-white antialiased">
         <div className="relative min-h-screen overflow-hidden">
           <div className="pointer-events-none absolute inset-0 overflow-hidden">
-            <div className="absolute -top-56 left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-blue-500/25 blur-[140px]" />
-            <div className="absolute bottom-[-20%] right-[-5%] h-[30rem] w-[30rem] rounded-full bg-purple-500/25 blur-[140px]" />
-            <div className="absolute inset-0 opacity-70 mix-blend-screen [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0.75),transparent_70%)]">
-              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),transparent_60%)]" />
-              <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(168,85,247,0.2),transparent_65%)]" />
+            <div className="absolute -top-64 left-1/2 h-[42rem] w-[42rem] -translate-x-1/2 rounded-full bg-sky-400/30 blur-[160px]" />
+            <div className="absolute top-1/3 -left-32 h-[28rem] w-[28rem] rounded-full bg-violet-500/25 blur-[160px]" />
+            <div className="absolute bottom-[-20%] right-[-5%] h-[34rem] w-[34rem] rounded-full bg-purple-500/25 blur-[160px]" />
+            <div className="absolute inset-0 opacity-80 mix-blend-screen [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0.75),transparent_72%)]">
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.2),transparent_62%)]" />
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(168,85,247,0.18),transparent_70%)]" />
             </div>
-            <div className="absolute inset-0 opacity-20 [mask-image:linear-gradient(to_bottom,rgba(0,0,0,0)_0%,rgba(0,0,0,1)_20%,rgba(0,0,0,1)_80%,rgba(0,0,0,0)_100%)]">
-              <div className="absolute inset-0 bg-[conic-gradient(from_120deg_at_50%_50%,rgba(148,163,184,0.2),transparent_60%,rgba(148,163,184,0.2))]" />
+            <div className="absolute inset-0 opacity-25 [mask-image:linear-gradient(to_bottom,rgba(0,0,0,0)_0%,rgba(0,0,0,1)_18%,rgba(0,0,0,1)_82%,rgba(0,0,0,0)_100%)]">
+              <div className="absolute inset-0 bg-[conic-gradient(from_130deg_at_50%_50%,rgba(148,163,184,0.18),transparent_60%,rgba(148,163,184,0.18))]" />
             </div>
-            <div className="absolute inset-x-0 top-1/2 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+            <div className="absolute inset-x-0 top-[22%] h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+            <div className="absolute inset-x-0 bottom-[18%] h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
           </div>
 
           <div className="relative z-10 flex min-h-screen flex-col">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -241,55 +241,6 @@ function SaltedPixelWebsite() {
         style={{ y: y2 }}
       />
 
-      {/* Navigation */}
-     <nav className="relative z-50 flex items-center justify-between p-6">
-  {/* Logo + Navigation Links together on the left */}
-  <motion.div
-    className="flex items-center space-x-8"
-    initial={{ opacity: 0, x: -20 }}
-    animate={{ opacity: 1, x: 0 }}
-    transition={{ duration: 0.6 }}
-  >
-    {/* Logo */}
-    <div className="flex items-center space-x-2">
-      <div className="w-10 h-10 bg-gradient-to-r from-blue-400 to-purple-500 rounded-lg flex items-center justify-center">
-        <Sparkles className="w-6 h-6 text-white" />
-      </div>
-      <span className="text-xl font-bold">SaltedPixel</span>
-    </div>
-
-    {/* Navigation links (moved left) */}
-    <div className="hidden md:flex items-center space-x-8">
-      <Link href="/services" className="text-gray-300 hover:text-white transition-colors">
-        Services
-      </Link>
-      <Link href="/about" className="text-gray-300 hover:text-white transition-colors">
-        About
-      </Link>
-      <Link href="/contact" className="text-gray-300 hover:text-white transition-colors">
-        Contact
-      </Link>
-    </div>
-  </motion.div>
-
-  {/* "Get Started" button stays on the far right */}
-  <motion.div
-    initial={{ opacity: 0, x: 20 }}
-    animate={{ opacity: 1, x: 0 }}
-    transition={{ duration: 0.6, delay: 0.4 }}
-  >
-    <Button
-      asChild
-      className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
-    >
-      <Link href="/get-started" className="flex items-center gap-2">
-        Get Started
-        <ArrowRight className="w-4 h-4" />
-      </Link>
-    </Button>
-  </motion.div>
-</nav>
-
       {/* Hero Section */}
       <section ref={sectionRef} className="relative z-10 container mx-auto px-4 pt-20 pb-32">
         <motion.div

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -224,7 +224,7 @@ function SaltedPixelWebsite() {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 text-white overflow-hidden">
+    <div className="relative min-h-screen overflow-hidden bg-[linear-gradient(to_bottom,#0a1a3f,#132b63_60%,rgba(5,11,23,0.95))] text-white">
       {/* Background Effects */}
       <div className="absolute inset-0">
         <FloatingPaths position={1} />

--- a/components/marketing-page.tsx
+++ b/components/marketing-page.tsx
@@ -39,84 +39,69 @@ export function MarketingPage({
   footerNote,
 }: MarketingPageProps) {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-56 left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-blue-500/25 blur-[140px]" />
-        <div className="absolute bottom-[-20%] right-[-5%] h-[30rem] w-[30rem] rounded-full bg-purple-500/25 blur-[140px]" />
-        <div className="absolute inset-0 opacity-70 mix-blend-screen [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0.75),transparent_70%)]">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),transparent_60%)]" />
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(168,85,247,0.2),transparent_65%)]" />
-        </div>
-        <div className="absolute inset-0 opacity-20 [mask-image:linear-gradient(to_bottom,rgba(0,0,0,0)_0%,rgba(0,0,0,1)_20%,rgba(0,0,0,1)_80%,rgba(0,0,0,0)_100%)]">
-          <div className="absolute inset-0 bg-[conic-gradient(from_120deg_at_50%_50%,rgba(148,163,184,0.2),transparent_60%,rgba(148,163,184,0.2))]" />
-        </div>
-        <div className="absolute inset-x-0 top-1/2 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
-      </div>
-
-      <div className="relative">
-        <div className="container mx-auto px-4 pb-16 pt-32">
-          <div className="max-w-4xl">
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-sky-200">
-              {eyebrow}
-            </span>
-            <h1 className="mt-8 text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
-              {title}
-            </h1>
-            <p className="mt-6 text-lg text-slate-200 md:text-xl">
-              {description}
-            </p>
-            <div className="mt-10 flex flex-wrap gap-4">
+    <section className="relative z-10">
+      <div className="container mx-auto px-4 pb-16 pt-32">
+        <div className="max-w-4xl">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-sky-200">
+            {eyebrow}
+          </span>
+          <h1 className="mt-8 text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
+            {title}
+          </h1>
+          <p className="mt-6 text-lg text-slate-200 md:text-xl">
+            {description}
+          </p>
+          <div className="mt-10 flex flex-wrap gap-4">
+            <Button
+              asChild
+              size="lg"
+              className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+            >
+              <Link href={primaryCta.href} className="flex items-center gap-2">
+                {primaryCta.label}
+                {primaryCta.icon ?? <ArrowRight className="h-5 w-5" />}
+              </Link>
+            </Button>
+            {secondaryCta ? (
               <Button
                 asChild
                 size="lg"
-                className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+                variant={secondaryCta.variant ?? "outline"}
+                className="border-white/20 text-white hover:bg-white/10"
               >
-                <Link href={primaryCta.href} className="flex items-center gap-2">
-                  {primaryCta.label}
-                  {primaryCta.icon ?? <ArrowRight className="h-5 w-5" />}
+                <Link href={secondaryCta.href} className="flex items-center gap-2">
+                  {secondaryCta.icon ?? <ArrowLeft className="h-5 w-5" />}
+                  {secondaryCta.label}
                 </Link>
               </Button>
-              {secondaryCta ? (
-                <Button
-                  asChild
-                  size="lg"
-                  variant={secondaryCta.variant ?? "outline"}
-                  className="border-white/20 text-white hover:bg-white/10"
-                >
-                  <Link href={secondaryCta.href} className="flex items-center gap-2">
-                    {secondaryCta.icon ?? <ArrowLeft className="h-5 w-5" />}
-                    {secondaryCta.label}
-                  </Link>
-                </Button>
-              ) : null}
-            </div>
+            ) : null}
           </div>
-        </div>
-
-        <div className="container mx-auto px-4 pb-32">
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {highlights.map((highlight, index) => (
-              <div
-                key={index}
-                className="group rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_45px_-35px_rgba(15,23,42,1)] backdrop-blur-lg transition-all duration-300 hover:-translate-y-1.5 hover:border-white/30 hover:bg-white/10"
-              >
-                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-300">
-                  {highlight.icon}
-                </div>
-                <h2 className="text-xl font-semibold text-white">{highlight.title}</h2>
-                <p className="mt-3 text-slate-200">{highlight.description}</p>
-              </div>
-            ))}
-          </div>
-
-          {footerNote ? (
-            <p className="mt-16 max-w-3xl text-sm uppercase tracking-[0.3em] text-slate-400">
-              {footerNote}
-            </p>
-          ) : null}
         </div>
       </div>
-    </div>
+
+      <div className="container mx-auto px-4 pb-32">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {highlights.map((highlight, index) => (
+            <div
+              key={index}
+              className="group rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_45px_-35px_rgba(15,23,42,1)] backdrop-blur-lg transition-all duration-300 hover:-translate-y-1.5 hover:border-white/30 hover:bg-white/10"
+            >
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-300">
+                {highlight.icon}
+              </div>
+              <h2 className="text-xl font-semibold text-white">{highlight.title}</h2>
+              <p className="mt-3 text-slate-200">{highlight.description}</p>
+            </div>
+          ))}
+        </div>
+
+        {footerNote ? (
+          <p className="mt-16 max-w-3xl text-sm uppercase tracking-[0.3em] text-slate-400">
+            {footerNote}
+          </p>
+        ) : null}
+      </div>
+    </section>
   );
 }
 

--- a/components/marketing-page.tsx
+++ b/components/marketing-page.tsx
@@ -39,8 +39,20 @@ export function MarketingPage({
   footerNote,
 }: MarketingPageProps) {
   return (
-    <section className="relative z-10">
-      <div className="container mx-auto px-4 pb-16 pt-32">
+    <section className="relative z-10 mx-4 overflow-hidden rounded-[2.5rem] border border-white/10 bg-slate-950/30 shadow-[0_35px_90px_-45px_rgba(15,23,42,0.85)] backdrop-blur-3xl md:mx-8">
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.16),transparent_65%)]"
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(circle_at_bottom,_rgba(192,132,252,0.14),transparent_70%)]"
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-30 bg-[linear-gradient(160deg,rgba(15,23,42,0.65),rgba(15,23,42,0.35))] opacity-80"
+      />
+      <div className="relative container mx-auto px-4 pb-16 pt-32">
         <div className="max-w-4xl">
           <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-sky-200">
             {eyebrow}
@@ -79,12 +91,12 @@ export function MarketingPage({
         </div>
       </div>
 
-      <div className="container mx-auto px-4 pb-32">
+      <div className="relative container mx-auto px-4 pb-32">
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {highlights.map((highlight, index) => (
             <div
               key={index}
-              className="group rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_45px_-35px_rgba(15,23,42,1)] backdrop-blur-lg transition-all duration-300 hover:-translate-y-1.5 hover:border-white/30 hover:bg-white/10"
+              className="group rounded-2xl border border-white/15 bg-white/5 p-6 shadow-[0_25px_45px_-35px_rgba(15,23,42,1)] backdrop-blur-lg transition-all duration-300 hover:-translate-y-1.5 hover:border-white/40 hover:bg-white/15"
             >
               <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-300">
                 {highlight.icon}
@@ -96,7 +108,7 @@ export function MarketingPage({
         </div>
 
         {footerNote ? (
-          <p className="mt-16 max-w-3xl text-sm uppercase tracking-[0.3em] text-slate-400">
+          <p className="mt-16 max-w-3xl text-sm uppercase tracking-[0.3em] text-slate-300/80">
             {footerNote}
           </p>
         ) : null}

--- a/components/marketing-page.tsx
+++ b/components/marketing-page.tsx
@@ -40,14 +40,22 @@ export function MarketingPage({
 }: MarketingPageProps) {
   return (
     <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
-      <div className="pointer-events-none absolute inset-0">
-        <div className="absolute -top-32 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-blue-500/20 blur-3xl" />
-        <div className="absolute bottom-0 right-0 h-96 w-96 translate-x-1/3 bg-purple-500/20 blur-3xl" />
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-56 left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-blue-500/25 blur-[140px]" />
+        <div className="absolute bottom-[-20%] right-[-5%] h-[30rem] w-[30rem] rounded-full bg-purple-500/25 blur-[140px]" />
+        <div className="absolute inset-0 opacity-70 mix-blend-screen [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0.75),transparent_70%)]">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),transparent_60%)]" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(168,85,247,0.2),transparent_65%)]" />
+        </div>
+        <div className="absolute inset-0 opacity-20 [mask-image:linear-gradient(to_bottom,rgba(0,0,0,0)_0%,rgba(0,0,0,1)_20%,rgba(0,0,0,1)_80%,rgba(0,0,0,0)_100%)]">
+          <div className="absolute inset-0 bg-[conic-gradient(from_120deg_at_50%_50%,rgba(148,163,184,0.2),transparent_60%,rgba(148,163,184,0.2))]" />
+        </div>
+        <div className="absolute inset-x-0 top-1/2 h-px bg-gradient-to-r from-transparent via-white/20 to-transparent" />
       </div>
 
       <div className="relative">
-        <div className="container mx-auto px-4 pb-16 pt-24">
-          <div className="max-w-3xl">
+        <div className="container mx-auto px-4 pb-16 pt-32">
+          <div className="max-w-4xl">
             <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-sky-200">
               {eyebrow}
             </span>
@@ -85,12 +93,12 @@ export function MarketingPage({
           </div>
         </div>
 
-        <div className="container mx-auto px-4 pb-24">
+        <div className="container mx-auto px-4 pb-32">
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {highlights.map((highlight, index) => (
               <div
                 key={index}
-                className="group rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:border-white/20 hover:bg-white/10"
+                className="group rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_45px_-35px_rgba(15,23,42,1)] backdrop-blur-lg transition-all duration-300 hover:-translate-y-1.5 hover:border-white/30 hover:bg-white/10"
               >
                 <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-500/10 text-blue-300">
                   {highlight.icon}

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -8,9 +8,13 @@ import { Button } from "@/components/ui/button";
 
 export function SiteNav() {
   return (
-    <nav className="relative z-50 mx-6 mt-6 flex items-center justify-between rounded-full border border-white/15 bg-white/10 px-6 py-4 text-white shadow-lg backdrop-blur-xl">
+    <nav className="relative z-50 mx-6 mt-6 flex items-center justify-between overflow-hidden rounded-full border border-white/10 bg-white/5 px-6 py-4 text-white shadow-[0_25px_55px_-30px_rgba(15,23,42,0.9)] backdrop-blur-2xl">
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(96,165,250,0.25),transparent_45%)]"
+      />
       <motion.div
-        className="flex items-center space-x-8"
+        className="relative z-10 flex items-center space-x-8"
         initial={{ opacity: 0, x: -20 }}
         animate={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.6 }}
@@ -23,19 +27,20 @@ export function SiteNav() {
         </Link>
 
         <div className="hidden items-center space-x-8 md:flex">
-          <Link href="/services" className="text-gray-100 transition-colors hover:text-white">
+          <Link href="/services" className="text-white/80 transition-colors hover:text-white">
             Services
           </Link>
-          <Link href="/about" className="text-gray-100 transition-colors hover:text-white">
+          <Link href="/about" className="text-white/80 transition-colors hover:text-white">
             About
           </Link>
-          <Link href="/contact" className="text-gray-100 transition-colors hover:text-white">
+          <Link href="/contact" className="text-white/80 transition-colors hover:text-white">
             Contact
           </Link>
         </div>
       </motion.div>
 
       <motion.div
+        className="relative z-10"
         initial={{ opacity: 0, x: 20 }}
         animate={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.6, delay: 0.4 }}

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -8,19 +8,7 @@ import { Button } from "@/components/ui/button";
 
 export function SiteNav() {
   return (
-    <nav className="relative z-50 mx-6 mt-6 flex items-center justify-between gap-6 overflow-hidden rounded-full border border-white/15 bg-slate-900/30 px-6 py-4 text-white shadow-[0_28px_65px_-32px_rgba(15,23,42,0.95)] backdrop-blur-3xl">
-      <span
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.25),transparent_55%)]"
-      />
-      <span
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-20 bg-[linear-gradient(120deg,rgba(15,23,42,0.65),rgba(15,23,42,0.35))] opacity-90"
-      />
-      <span
-        aria-hidden
-        className="pointer-events-none absolute inset-x-10 -top-24 h-48 rounded-full bg-[radial-gradient(circle,rgba(236,72,153,0.25),transparent_70%)] opacity-60"
-      />
+    <nav className="relative z-50 mx-6 mt-6 flex items-center justify-between gap-6 rounded-full border border-white/10 px-6 py-4 text-white shadow-[0_22px_55px_-35px_rgba(10,26,63,0.85)] backdrop-blur-xl">
       <motion.div
         className="relative z-10 flex items-center space-x-8"
         initial={{ opacity: 0, x: -20 }}

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 
 export function SiteNav() {
   return (
-    <nav className="relative z-50 flex items-center justify-between p-6">
+    <nav className="relative z-50 mx-6 mt-6 flex items-center justify-between rounded-full border border-white/15 bg-white/10 px-6 py-4 text-white shadow-lg backdrop-blur-xl">
       <motion.div
         className="flex items-center space-x-8"
         initial={{ opacity: 0, x: -20 }}
@@ -19,17 +19,17 @@ export function SiteNav() {
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-r from-blue-400 to-purple-500">
             <Sparkles className="h-6 w-6 text-white" />
           </div>
-          <span className="text-xl font-bold">SaltedPixel</span>
+          <span className="text-xl font-bold text-white">SaltedPixel</span>
         </Link>
 
         <div className="hidden items-center space-x-8 md:flex">
-          <Link href="/services" className="text-gray-300 transition-colors hover:text-white">
+          <Link href="/services" className="text-gray-100 transition-colors hover:text-white">
             Services
           </Link>
-          <Link href="/about" className="text-gray-300 transition-colors hover:text-white">
+          <Link href="/about" className="text-gray-100 transition-colors hover:text-white">
             About
           </Link>
-          <Link href="/contact" className="text-gray-300 transition-colors hover:text-white">
+          <Link href="/contact" className="text-gray-100 transition-colors hover:text-white">
             Contact
           </Link>
         </div>

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Sparkles, ArrowRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export function SiteNav() {
+  return (
+    <nav className="relative z-50 flex items-center justify-between p-6">
+      <motion.div
+        className="flex items-center space-x-8"
+        initial={{ opacity: 0, x: -20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.6 }}
+      >
+        <Link href="/" className="flex items-center space-x-2">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-r from-blue-400 to-purple-500">
+            <Sparkles className="h-6 w-6 text-white" />
+          </div>
+          <span className="text-xl font-bold">SaltedPixel</span>
+        </Link>
+
+        <div className="hidden items-center space-x-8 md:flex">
+          <Link href="/services" className="text-gray-300 transition-colors hover:text-white">
+            Services
+          </Link>
+          <Link href="/about" className="text-gray-300 transition-colors hover:text-white">
+            About
+          </Link>
+          <Link href="/contact" className="text-gray-300 transition-colors hover:text-white">
+            Contact
+          </Link>
+        </div>
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, x: 20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.6, delay: 0.4 }}
+      >
+        <Button
+          asChild
+          className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+        >
+          <Link href="/get-started" className="flex items-center gap-2">
+            Get Started
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </Button>
+      </motion.div>
+    </nav>
+  );
+}
+
+export default SiteNav;

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -8,10 +8,18 @@ import { Button } from "@/components/ui/button";
 
 export function SiteNav() {
   return (
-    <nav className="relative z-50 mx-6 mt-6 flex items-center justify-between overflow-hidden rounded-full border border-white/10 bg-white/5 px-6 py-4 text-white shadow-[0_25px_55px_-30px_rgba(15,23,42,0.9)] backdrop-blur-2xl">
+    <nav className="relative z-50 mx-6 mt-6 flex items-center justify-between gap-6 overflow-hidden rounded-full border border-white/15 bg-slate-900/30 px-6 py-4 text-white shadow-[0_28px_65px_-32px_rgba(15,23,42,0.95)] backdrop-blur-3xl">
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(96,165,250,0.25),transparent_45%)]"
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.25),transparent_55%)]"
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-20 bg-[linear-gradient(120deg,rgba(15,23,42,0.65),rgba(15,23,42,0.35))] opacity-90"
+      />
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-x-10 -top-24 h-48 rounded-full bg-[radial-gradient(circle,rgba(236,72,153,0.25),transparent_70%)] opacity-60"
       />
       <motion.div
         className="relative z-10 flex items-center space-x-8"
@@ -47,7 +55,7 @@ export function SiteNav() {
       >
         <Button
           asChild
-          className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+          className="border border-white/20 bg-white/10 text-white transition-colors hover:border-white/40 hover:bg-white/20"
         >
           <Link href="/get-started" className="flex items-center gap-2">
             Get Started


### PR DESCRIPTION
## Summary
- extract the SaltedPixel navigation into a reusable `SiteNav` component
- render the shared navigation from the root layout so it appears on every page
- remove the duplicated navigation markup from the home page hero

## Testing
- npm run lint *(fails: command prompts for initial configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d83a219af88326882e71f1543b328e