### PR TITLE
Add fixed global navigation bar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,21 @@
-export const metadata = {
-  title: "SaltedPixel",
-  description: "Modern websites, local SEO, and AI automation."
-};
+import type { ReactNode } from "react";
+
+import FixedNavigation from "@/components/fixed-navigation";
 
 import "./../styles/globals.css";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export const metadata = {
+  title: "SaltedPixel",
+  description: "Modern websites, local SEO, and AI automation.",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <FixedNavigation />
+        <main className="pt-24">{children}</main>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -241,55 +241,6 @@ function SaltedPixelWebsite() {
         style={{ y: y2 }}
       />
 
-      {/* Navigation */}
-     <nav className="relative z-50 flex items-center justify-between p-6">
-  {/* Logo + Navigation Links together on the left */}
-  <motion.div
-    className="flex items-center space-x-8"
-    initial={{ opacity: 0, x: -20 }}
-    animate={{ opacity: 1, x: 0 }}
-    transition={{ duration: 0.6 }}
-  >
-    {/* Logo */}
-    <div className="flex items-center space-x-2">
-      <div className="w-10 h-10 bg-gradient-to-r from-blue-400 to-purple-500 rounded-lg flex items-center justify-center">
-        <Sparkles className="w-6 h-6 text-white" />
-      </div>
-      <span className="text-xl font-bold">SaltedPixel</span>
-    </div>
-
-    {/* Navigation links (moved left) */}
-    <div className="hidden md:flex items-center space-x-8">
-      <Link href="/services" className="text-gray-300 hover:text-white transition-colors">
-        Services
-      </Link>
-      <Link href="/about" className="text-gray-300 hover:text-white transition-colors">
-        About
-      </Link>
-      <Link href="/contact" className="text-gray-300 hover:text-white transition-colors">
-        Contact
-      </Link>
-    </div>
-  </motion.div>
-
-  {/* "Get Started" button stays on the far right */}
-  <motion.div
-    initial={{ opacity: 0, x: 20 }}
-    animate={{ opacity: 1, x: 0 }}
-    transition={{ duration: 0.6, delay: 0.4 }}
-  >
-    <Button
-      asChild
-      className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
-    >
-      <Link href="/get-started" className="flex items-center gap-2">
-        Get Started
-        <ArrowRight className="w-4 h-4" />
-      </Link>
-    </Button>
-  </motion.div>
-</nav>
-
       {/* Hero Section */}
       <section ref={sectionRef} className="relative z-10 container mx-auto px-4 pt-20 pb-32">
         <motion.div

--- a/components/fixed-navigation.tsx
+++ b/components/fixed-navigation.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Sparkles, ArrowRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export function FixedNavigation() {
+  return (
+    <nav className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between p-6">
+      <motion.div
+        className="flex items-center space-x-8"
+        initial={{ opacity: 0, x: -20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.6 }}
+      >
+        <div className="flex items-center space-x-2">
+          <div className="w-10 h-10 bg-gradient-to-r from-blue-400 to-purple-500 rounded-lg flex items-center justify-center">
+            <Sparkles className="w-6 h-6 text-white" />
+          </div>
+          <span className="text-xl font-bold">SaltedPixel</span>
+        </div>
+
+        <div className="hidden md:flex items-center space-x-8">
+          <Link href="/services" className="text-gray-300 hover:text-white transition-colors">
+            Services
+          </Link>
+          <Link href="/about" className="text-gray-300 hover:text-white transition-colors">
+            About
+          </Link>
+          <Link href="/contact" className="text-gray-300 hover:text-white transition-colors">
+            Contact
+          </Link>
+        </div>
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, x: 20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.6, delay: 0.4 }}
+      >
+        <Button
+          asChild
+          className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+        >
+          <Link href="/get-started" className="flex items-center gap-2">
+            Get Started
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </Button>
+      </motion.div>
+    </nav>
+  );
+}
+
+export default FixedNavigation;


### PR DESCRIPTION
## Summary
- add a reusable fixed navigation component that preserves the SaltedPixel logo and link spacing
- mount the navigation from the root layout so it stays visible on every page
- add top padding to the main content area to avoid overlap with the fixed navigation

## Testing
- npm run lint *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e194a235948326bd68696b55e3b368