### PR TITLE
Ensure navigation is consistent across pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,10 +3,10 @@
 import React, { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { motion, useScroll, useTransform, useInView, useSpring } from "framer-motion";
-import { 
-  Globe, 
-  Search, 
-  Bot, 
+import {
+  Globe,
+  Search,
+  Bot,
   Star, 
   Users, 
   TrendingUp, 
@@ -21,6 +21,7 @@ import {
   MessageSquare
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import SiteNav from "@/components/site-nav";
 
 // Utility function for className merging
 function cn(...classes: (string | undefined | null | false)[]): string {
@@ -242,53 +243,7 @@ function SaltedPixelWebsite() {
       />
 
       {/* Navigation */}
-     <nav className="relative z-50 flex items-center justify-between p-6">
-  {/* Logo + Navigation Links together on the left */}
-  <motion.div
-    className="flex items-center space-x-8"
-    initial={{ opacity: 0, x: -20 }}
-    animate={{ opacity: 1, x: 0 }}
-    transition={{ duration: 0.6 }}
-  >
-    {/* Logo */}
-    <div className="flex items-center space-x-2">
-      <div className="w-10 h-10 bg-gradient-to-r from-blue-400 to-purple-500 rounded-lg flex items-center justify-center">
-        <Sparkles className="w-6 h-6 text-white" />
-      </div>
-      <span className="text-xl font-bold">SaltedPixel</span>
-    </div>
-
-    {/* Navigation links (moved left) */}
-    <div className="hidden md:flex items-center space-x-8">
-      <Link href="/services" className="text-gray-300 hover:text-white transition-colors">
-        Services
-      </Link>
-      <Link href="/about" className="text-gray-300 hover:text-white transition-colors">
-        About
-      </Link>
-      <Link href="/contact" className="text-gray-300 hover:text-white transition-colors">
-        Contact
-      </Link>
-    </div>
-  </motion.div>
-
-  {/* "Get Started" button stays on the far right */}
-  <motion.div
-    initial={{ opacity: 0, x: 20 }}
-    animate={{ opacity: 1, x: 0 }}
-    transition={{ duration: 0.6, delay: 0.4 }}
-  >
-    <Button
-      asChild
-      className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
-    >
-      <Link href="/get-started" className="flex items-center gap-2">
-        Get Started
-        <ArrowRight className="w-4 h-4" />
-      </Link>
-    </Button>
-  </motion.div>
-</nav>
+      <SiteNav />
 
       {/* Hero Section */}
       <section ref={sectionRef} className="relative z-10 container mx-auto px-4 pt-20 pb-32">

--- a/components/marketing-page.tsx
+++ b/components/marketing-page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import SiteNav from "@/components/site-nav";
 
 interface CtaLink {
   label: string;
@@ -46,6 +47,7 @@ export function MarketingPage({
       </div>
 
       <div className="relative">
+        <SiteNav />
         <div className="container mx-auto px-4 pb-16 pt-24">
           <div className="max-w-3xl">
             <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-sky-200">

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { ArrowRight, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export function SiteNav() {
+  return (
+    <nav className="relative z-50 flex items-center justify-between p-6">
+      <motion.div
+        className="flex items-center space-x-8"
+        initial={{ opacity: 0, x: -20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.6 }}
+      >
+        <div className="flex items-center space-x-2">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-r from-blue-400 to-purple-500">
+            <Sparkles className="h-6 w-6 text-white" />
+          </div>
+          <span className="text-xl font-bold">SaltedPixel</span>
+        </div>
+
+        <div className="hidden items-center space-x-8 md:flex">
+          <Link href="/services" className="text-gray-300 transition-colors hover:text-white">
+            Services
+          </Link>
+          <Link href="/about" className="text-gray-300 transition-colors hover:text-white">
+            About
+          </Link>
+          <Link href="/contact" className="text-gray-300 transition-colors hover:text-white">
+            Contact
+          </Link>
+        </div>
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, x: 20 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.6, delay: 0.4 }}
+      >
+        <Button
+          asChild
+          className="bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700"
+        >
+          <Link href="/get-started" className="flex items-center gap-2">
+            Get Started
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </Button>
+      </motion.div>
+    </nav>
+  );
+}
+
+export default SiteNav;


### PR DESCRIPTION
## Summary
- extract the site navigation into a dedicated component for reuse
- render the shared navigation on the home page and all marketing subpages to keep links and text consistent

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e19a2bd2e083268e898da1a82f0a32